### PR TITLE
Make gun logging optional to make log file clear to read

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -113,7 +113,10 @@ namespace CenturionCC.System.Gun
         protected virtual void OnTriggerEnter(Collider other)
         {
             var otherName = other.name.ToLower();
+
+#if CENTURIONSYSTEM_GUN_LOGGING || CENTURIONSYSTEM_VERBOSE_LOGGING
             Logger.LogVerbose($"{Prefix}OnTriggerEnter: {otherName}");
+#endif
 
             if (otherName.StartsWith("safezone"))
             {
@@ -202,8 +205,10 @@ namespace CenturionCC.System.Gun
             if (ShotCount == _lastShotCount)
                 return;
 
+#if CENTURIONSYSTEM_GUN_LOGGING || CENTURIONSYSTEM_VERBOSE_LOGGING
             Logger.LogVerbose(
                 $"{Prefix}Received new shot: {ShotCount}:{QueuedShotCount}, {_shotPosition.ToString("2F")}, {_shotRotation.eulerAngles.ToString("2F")}");
+#endif
 
             if (ShotCount <= 0 || _lastShotCount == -1)
             {

--- a/Packages/org.centurioncc.system/Runtime/Gun/ManagedGun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/ManagedGun.cs
@@ -128,7 +128,10 @@ namespace CenturionCC.System.Gun
 
         private void Internal_SetVariantData(GunVariantDataStore data, bool refreshHandleOffset)
         {
+#if CENTURIONSYSTEM_GUN_LOGGING || CENTURIONSYSTEM_VERBOSE_LOGGING
             Logger.LogVerbose($"{Prefix}Internal_SetVariantData: {data.UniqueId}");
+#endif
+
             // Set unique id
             _variantDataUniqueId = data.UniqueId;
 
@@ -188,7 +191,10 @@ namespace CenturionCC.System.Gun
 
         private void Internal_ResetVariantData()
         {
+#if CENTURIONSYSTEM_GUN_LOGGING || CENTURIONSYSTEM_VERBOSE_LOGGING
             Logger.LogVerbose($"{Prefix}ResetVariantData");
+#endif
+
             if (Behaviour != null)
                 Behaviour.Dispose(this);
 


### PR DESCRIPTION
Added `CENTURIONSYSTEM_GUN_LOGGING` symbol to enable gun logging
`CENTURIONSYSTEM_VERBOSE_LOGGING` symbol will also enable this