### PR TITLE
Fix queued shots firing while CanShoot returning `ShotResult.Cancelled`

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -177,6 +177,12 @@ namespace CenturionCC.System.Gun
             if (QueuedShotCount <= 0)
                 return;
 
+            if (CanShoot() == ShotResult.Cancelled)
+            {
+                QueuedShotCount = 0;
+                return;
+            }
+
             _shotPosition = ShooterPosition;
             _shotRotation = ShooterRotation;
             _shotTime = Networking.GetNetworkDateTime().Ticks;


### PR DESCRIPTION
Fixes #75 