### PR TITLE
Fix gun audio played position wrong for hidden mass gun models

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -863,7 +863,7 @@ namespace CenturionCC.System.Gun
                 Internal_PlayAudio(AudioData.EmptyShooting);
         }
 
-        protected void Internal_PlayAudio(AudioDataStore audioStore)
+        protected virtual void Internal_PlayAudio(AudioDataStore audioStore)
         {
             AudioManager.PlayAudioAtTransform(audioStore, Target);
         }

--- a/Packages/org.centurioncc.system/Runtime/Gun/MassGun/GunModel.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/MassGun/GunModel.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using CenturionCC.System.Audio;
+using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
 
@@ -59,6 +60,11 @@ namespace CenturionCC.System.Gun.MassGun
                 Networking.LocalPlayer.PlayHapticEventInHand(MainHandle.CurrentHand, .2F, .02F, .1F);
                 Networking.LocalPlayer.PlayHapticEventInHand(SubHandle.CurrentHand, .2F, .02F, .1F);
             }
+        }
+
+        protected override void Internal_PlayAudio(AudioDataStore audioStore)
+        {
+            AudioManager.PlayAudioAtTransform(audioStore, MainHandle.transform);
         }
     }
 }


### PR DESCRIPTION
Because this issue does not affect `Gun.cs` or `ManagedGun.cs`, I've only changed `GunModel#Internal_PlayAudio(AudioDataStore)` behavior.

Fixes #78