### PR TITLE
Add more options to `ExternalHitDisplayManager`

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.asset
+++ b/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 6
     - Name: 
       Entry: 7
       Data: 
@@ -228,6 +228,211 @@ MonoBehaviour:
     - Name: 
       Entry: 7
       Data: 16|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: playHitDisplay
+    - Name: $v
+      Entry: 7
+      Data: 17|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: playHitDisplay
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 18|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: CenturionCC.System.Player.External.HitDisplay.HitDisplaySetting, CenturionCC.System
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 19|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 20|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 21|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 22|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: 'Always will play any hits (Local & Remote).
+
+        Local will play
+        when local player was an attacker.
+
+        Remote will play when local player
+        was not an attacker.'
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: playWhenLocalIsNotInGame
+    - Name: $v
+      Entry: 7
+      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: playWhenLocalIsNotInGame
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 24|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 26|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: bypassPlayHitDisplayWhenStaffTeam
+    - Name: $v
+      Entry: 7
+      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: bypassPlayHitDisplayWhenStaffTeam
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 24
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 29|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 30|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Bypasses Play Hit Display setting and plays any hits when you're in staff
+        team
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.cs
@@ -1,4 +1,5 @@
 ﻿using DerpyNewbie.Common;
+using JetBrains.Annotations;
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -15,6 +16,45 @@ namespace CenturionCC.System.Player.External.HitDisplay
         private GameObject sourceExternalHitDisplay;
         [SerializeField]
         private Transform parent;
+        [SerializeField] [Tooltip("Always will play any hits (Local & Remote).\n" +
+                                  "Local will play when local player was an attacker.\n" +
+                                  "Remote will play when local player was not an attacker.")]
+        private HitDisplaySetting playHitDisplay = HitDisplaySetting.Always;
+        [SerializeField]
+        private bool playWhenLocalIsNotInGame = true;
+        [SerializeField] [Tooltip("Bypasses Play Hit Display setting and plays any hits when you're in staff team")]
+        private bool bypassPlayHitDisplayWhenStaffTeam = true;
+
+        /// <summary>
+        /// When to play HitDisplay?
+        /// </summary>
+        /// <remarks>
+        /// When player was killed, This will be checked against player information.
+        /// See <see cref="HitDisplaySetting"/> for each setting's behaviour.
+        /// </remarks>
+        /// <seealso cref="HitDisplaySetting"/>
+        /// <seealso cref="playWhenLocalIsNotInGame"/>
+        /// <seealso cref="bypassPlayHitDisplayWhenStaffTeam"/>
+        [PublicAPI]
+        public HitDisplaySetting PlayHitDisplay
+        {
+            get => playHitDisplay;
+            set => playHitDisplay = value;
+        }
+
+        [PublicAPI]
+        public bool PlayWhenLocalIsNotInGame
+        {
+            get => playWhenLocalIsNotInGame;
+            set => playWhenLocalIsNotInGame = value;
+        }
+
+        [PublicAPI]
+        public bool BypassPlayHitDisplayWhenStaffTeam
+        {
+            get => bypassPlayHitDisplayWhenStaffTeam;
+            set => bypassPlayHitDisplayWhenStaffTeam = value;
+        }
 
         private void Start()
         {
@@ -26,10 +66,38 @@ namespace CenturionCC.System.Player.External.HitDisplay
 
         public override void OnKilled(PlayerBase attacker, PlayerBase victim, KillType type)
         {
-            if (victim.IsLocal)
+            var localPlayer = playerManager.GetLocalPlayer();
+            if (localPlayer == null)
+            {
+                if (playWhenLocalIsNotInGame) Play(victim);
                 return;
+            }
 
-            Play(victim);
+            if (playerManager.IsStaffTeamId(localPlayer.TeamId) && bypassPlayHitDisplayWhenStaffTeam)
+            {
+                Play(victim);
+                return;
+            }
+
+            switch (playHitDisplay)
+            {
+                default:
+                case HitDisplaySetting.Always:
+                {
+                    Play(victim);
+                    return;
+                }
+                case HitDisplaySetting.LocalOnly:
+                {
+                    if (attacker.IsLocal) Play(victim);
+                    return;
+                }
+                case HitDisplaySetting.RemoteOnly:
+                {
+                    if (!attacker.IsLocal) Play(victim);
+                    return;
+                }
+            }
         }
 
         public void Play(PlayerBase player)
@@ -57,10 +125,25 @@ namespace CenturionCC.System.Player.External.HitDisplay
         }
     }
 
+    /// <summary>
+    /// HitDisplay behaviour setting.
+    /// </summary>
+    /// <seealso cref="HitDisplaySetting.Always"/>
+    /// <seealso cref="HitDisplaySetting.LocalOnly"/>
+    /// <seealso cref="HitDisplaySetting.RemoteOnly"/>
     public enum HitDisplaySetting
     {
+        /// <summary>
+        /// Will play any hits.
+        /// </summary>
         Always,
+        /// <summary>
+        /// Will only play when attacker was local.
+        /// </summary>
         LocalOnly,
+        /// <summary>
+        /// Will only play when attacker was remote.
+        /// </summary>
         RemoteOnly
     }
 }

--- a/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/External/HitDisplay/ExternalHitDisplayManager.cs
@@ -24,12 +24,12 @@ namespace CenturionCC.System.Player.External.HitDisplay
                 parent = transform;
         }
 
-        public override void OnKilled(PlayerBase firedPlayer, PlayerBase hitPlayer)
+        public override void OnKilled(PlayerBase attacker, PlayerBase victim, KillType type)
         {
-            if (hitPlayer.IsLocal)
+            if (victim.IsLocal)
                 return;
 
-            Play(hitPlayer);
+            Play(victim);
         }
 
         public void Play(PlayerBase player)
@@ -55,5 +55,12 @@ namespace CenturionCC.System.Player.External.HitDisplay
                 Destroy(obj.gameObject);
             }
         }
+    }
+
+    public enum HitDisplaySetting
+    {
+        Always,
+        LocalOnly,
+        RemoteOnly
     }
 }


### PR DESCRIPTION
Closes #73

Adds these options to make more customization available within inspector:
|  Name                                       | Description                                                                              | Default Value  | 
| -------------------------------- | --------------------------------------------------------------- | -------------- |
| Play Hit Display                          | Configure when to play HitDisplay                                           | Always            |
| Play When Local Is Not In Game | Bypasses `Play Hit Display` setting when not in game              | `true`              |
| Bypass Play Hit Display When Staff Team | Bypasses `Play Hit Display` setting when in staff team | `true`              |