### PR TITLE
Revert "Fix LookAtTargetOffset does not consider X/Z SubHandle offset"

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -564,15 +564,9 @@ namespace CenturionCC.System.Gun
         [PublicAPI]
         public virtual float SubHandleRePickupDelay => subHandleRePickupDelay;
         [PublicAPI]
-        public virtual Vector3 LookAtTargetOffset
-        {
-            get
-            {
-                var offset = MainHandlePositionOffset - SubHandlePositionOffset;
-                // I have no idea why multiplying z by -2 fixes x/z offset issue. but it fixes the problem, so who cares!
-                return new Vector3(offset.x, offset.y, offset.z * -2);
-            }
-        }
+        public virtual Vector3 LookAtTargetOffset =>
+            new Vector3(0, MainHandlePositionOffset.y - SubHandlePositionOffset.y, 0);
+
 
         /// <summary>
         /// Local position of where bullets shooting out from.


### PR DESCRIPTION
Reverts Centurion-Creative-Connect/System#150 to fix issue #161 