### PR TITLE
Add Second Twist Audio for GunAudioDataStore

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/DataStore/GunAudioDataStore.asset
+++ b/Packages/org.centurioncc.system/Runtime/Gun/DataStore/GunAudioDataStore.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 11
+      Data: 14
     - Name: 
       Entry: 7
       Data: 
@@ -470,13 +470,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: cockingPullAudio
+      Data: cockingSecondTwistAudio
     - Name: $v
       Entry: 7
       Data: 29|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: cockingPullAudio
+      Data: cockingSecondTwistAudio
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 8
@@ -524,13 +524,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: cockingPullOffset
+      Data: cockingSecondTwistOffset
     - Name: $v
       Entry: 7
       Data: 32|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: cockingPullOffset
+      Data: cockingSecondTwistOffset
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 13
@@ -578,13 +578,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: cockingReleaseAudio
+      Data: cockingPullAudio
     - Name: $v
       Entry: 7
       Data: 35|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: cockingReleaseAudio
+      Data: cockingPullAudio
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 8
@@ -632,13 +632,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: cockingReleaseOffset
+      Data: cockingPullOffset
     - Name: $v
       Entry: 7
       Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: cockingReleaseOffset
+      Data: cockingPullOffset
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 13
@@ -666,6 +666,183 @@ MonoBehaviour:
     - Name: 
       Entry: 7
       Data: 40|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: cockingReleaseAudio
+    - Name: $v
+      Entry: 7
+      Data: 41|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: cockingReleaseAudio
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 8
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 4
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 42|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 43|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: cockingReleaseOffset
+    - Name: $v
+      Entry: 7
+      Data: 44|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: cockingReleaseOffset
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 13
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 13
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 46|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: useSecondTwistAudio
+    - Name: $v
+      Entry: 7
+      Data: 47|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: useSecondTwistAudio
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 48|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 48
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 49|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 50|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
+    - Name: header
+      Entry: 1
+      Data: Options
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 51|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/org.centurioncc.system/Runtime/Gun/DataStore/GunAudioDataStore.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/DataStore/GunAudioDataStore.cs
@@ -26,6 +26,10 @@ namespace CenturionCC.System.Gun.DataStore
         [SerializeField]
         private Vector3 cockingTwistOffset;
         [SerializeField]
+        private AudioDataStore cockingSecondTwistAudio;
+        [SerializeField]
+        private Vector3 cockingSecondTwistOffset;
+        [SerializeField]
         private AudioDataStore cockingPullAudio;
         [SerializeField]
         private Vector3 cockingPullOffset;
@@ -34,6 +38,10 @@ namespace CenturionCC.System.Gun.DataStore
         [SerializeField]
         private Vector3 cockingReleaseOffset;
 
+        [Header("Options")]
+        [SerializeField]
+        private bool useSecondTwistAudio = false;
+
         public CollisionAudioStore Collision => collisionAudio;
         public AudioDataStore Shooting => shootingAudio;
         public Vector3 ShootingOffset => shootingOffset;
@@ -41,9 +49,14 @@ namespace CenturionCC.System.Gun.DataStore
         public Vector3 EmptyShootingOffset => emptyShootingOffset;
         public AudioDataStore CockingTwist => cockingTwistAudio;
         public Vector3 CockingTwistOffset => cockingTwistOffset;
+        public AudioDataStore CockingSecondTwist => cockingSecondTwistAudio;
+        public Vector3 CockingSecondTwistOffset => cockingSecondTwistOffset;
         public AudioDataStore CockingPull => cockingPullAudio;
         public Vector3 CockingPullOffset => cockingPullOffset;
         public AudioDataStore CockingRelease => cockingReleaseAudio;
         public Vector3 CockingReleaseOffset => cockingReleaseOffset;
+
+        // NOTE: for compatibility
+        public bool UseSecondTwistAudio => useSecondTwistAudio;
     }
 }

--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -1215,7 +1215,24 @@ namespace CenturionCC.System.Gun
 
             if (nextState == GunState.InCockingTwisting && previousState != GunState.InCockingTwisting)
             {
-                if (AudioData != null) Internal_PlayAudio(AudioData.CockingTwist, AudioData.CockingTwistOffset);
+                if (AudioData != null)
+                {
+                    if (!AudioData.UseSecondTwistAudio)
+                    {
+                        Internal_PlayAudio(AudioData.CockingTwist, AudioData.CockingTwistOffset);
+                    }
+                    else
+                    {
+                        if (previousState == GunState.InCockingPush || previousState == GunState.InCockingPull)
+                        {
+                            Internal_PlayAudio(AudioData.CockingSecondTwist, AudioData.CockingSecondTwistOffset);
+                        }
+                        else
+                        {
+                            Internal_PlayAudio(AudioData.CockingTwist, AudioData.CockingTwistOffset);
+                        }
+                    }
+                }
 
                 if (TargetAnimator != null && !IsLocal)
                     TargetAnimator.SetFloat(GunUtility.CockingTwistParameter(), 1);


### PR DESCRIPTION
There was audio for 
- to `InCockingTwisting` (CockingTwist)
- to `InCockingPush` (CockingPull)
- to `Idle` (Release)
problem is that twisting audio should be different depending previous state, such as
1. from `Idle` to `InCockingTwisting`
  - This should only contain twisting ended sfx
2. from `Pull` or `Push` to `InCockingTwisting`
  - This should contain pushing ended sfx
to fix this problem, I've added `CockingSecondTwist`.

When `UseSecondTwistAudio` is checked, `CockingTwist` will be played in 1st case, `CockingSecondTwist` will be played in 2nd case.
else it'll behave same as before (`CockingTwist` will be played in both 1st and 2nd cases)