### PR TITLE
Add SyncResultContext for Player Hit Data

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncer.asset
+++ b/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncer.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 32
+      Data: 34
     - Name: 
       Entry: 7
       Data: 
@@ -998,25 +998,31 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <EventId>k__BackingField
+      Data: _localResultContext
     - Name: $v
       Entry: 7
       Data: 52|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <EventId>k__BackingField
+      Data: _localResultContext
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 14
+      Entry: 7
+      Data: 53|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Byte, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 14
+      Data: 53
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
     - Name: 
-      Entry: 3
-      Data: 1
+      Entry: 6
+      Data: 
     - Name: 
       Entry: 8
       Data: 
@@ -1025,16 +1031,10 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 53|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 54|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 54|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
-    - Name: 
-      Entry: 8
-      Data: 
+      Data: 0
     - Name: 
       Entry: 13
       Data: 
@@ -1052,13 +1052,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <SenderId>k__BackingField
+      Data: <EventId>k__BackingField
     - Name: $v
       Entry: 7
       Data: 55|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <SenderId>k__BackingField
+      Data: <EventId>k__BackingField
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 14
@@ -1069,8 +1069,8 @@ MonoBehaviour:
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
     - Name: 
-      Entry: 6
-      Data: 
+      Entry: 3
+      Data: 1
     - Name: 
       Entry: 8
       Data: 
@@ -1082,6 +1082,60 @@ MonoBehaviour:
       Data: 56|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 57|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: <SenderId>k__BackingField
+    - Name: $v
+      Entry: 7
+      Data: 58|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: <SenderId>k__BackingField
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 14
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 14
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 59|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
       Data: 0
     - Name: 
       Entry: 13
@@ -1103,7 +1157,7 @@ MonoBehaviour:
       Data: <VictimId>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 57|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 60|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <VictimId>k__BackingField
@@ -1127,7 +1181,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 58|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 61|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1151,7 +1205,7 @@ MonoBehaviour:
       Data: <AttackerId>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 59|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 62|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <AttackerId>k__BackingField
@@ -1175,7 +1229,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 60|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 63|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1197,66 +1251,12 @@ MonoBehaviour:
     - Name: $k
       Entry: 1
       Data: <ActivatedPosition>k__BackingField
-    - Name: $v
-      Entry: 7
-      Data: 61|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: <ActivatedPosition>k__BackingField
-    - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 26
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 26
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 3
-      Data: 1
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 62|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 63|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: <HitPosition>k__BackingField
     - Name: $v
       Entry: 7
       Data: 64|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <HitPosition>k__BackingField
+      Data: <ActivatedPosition>k__BackingField
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 26
@@ -1304,25 +1304,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <ActivatedTimeTicks>k__BackingField
+      Data: <HitPosition>k__BackingField
     - Name: $v
       Entry: 7
       Data: 67|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <ActivatedTimeTicks>k__BackingField
+      Data: <HitPosition>k__BackingField
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 68|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: System.Int64, mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 26
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 68
+      Data: 26
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1337,13 +1331,13 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 69|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 68|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 70|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+      Data: 69|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -1364,19 +1358,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <HitTimeTicks>k__BackingField
+      Data: <ActivatedTimeTicks>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 71|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 70|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <HitTimeTicks>k__BackingField
+      Data: <ActivatedTimeTicks>k__BackingField
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 68
+      Entry: 7
+      Data: 71|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int64, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 68
+      Data: 71
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1418,19 +1418,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <WeaponType>k__BackingField
+      Data: <HitTimeTicks>k__BackingField
     - Name: $v
       Entry: 7
       Data: 74|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <WeaponType>k__BackingField
+      Data: <HitTimeTicks>k__BackingField
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 50
+      Data: 71
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 50
+      Data: 71
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1472,10 +1472,64 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <State>k__BackingField
+      Data: <WeaponType>k__BackingField
     - Name: $v
       Entry: 7
       Data: 77|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: <WeaponType>k__BackingField
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 50
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 50
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 78|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 79|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: <State>k__BackingField
+    - Name: $v
+      Entry: 7
+      Data: 80|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <State>k__BackingField
@@ -1499,7 +1553,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 78|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 81|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1523,7 +1577,7 @@ MonoBehaviour:
       Data: <Result>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 79|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 82|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <Result>k__BackingField
@@ -1547,7 +1601,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 80|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 83|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1571,7 +1625,7 @@ MonoBehaviour:
       Data: <Type>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 81|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 84|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <Type>k__BackingField
@@ -1595,7 +1649,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 82|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 85|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1619,7 +1673,7 @@ MonoBehaviour:
       Data: <Parts>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 83|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 86|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: <Parts>k__BackingField
@@ -1643,7 +1697,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 84|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 87|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1664,19 +1718,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: <EncodedData>k__BackingField
+      Data: <ResultContext>k__BackingField
     - Name: $v
       Entry: 7
-      Data: 85|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 88|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: <EncodedData>k__BackingField
+      Data: <ResultContext>k__BackingField
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 68
+      Data: 53
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 68
+      Data: 53
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1691,13 +1745,67 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 86|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 89|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 87|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+      Data: 90|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: <EncodedData>k__BackingField
+    - Name: $v
+      Entry: 7
+      Data: 91|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: <EncodedData>k__BackingField
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 71
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 71
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 92|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 93|UdonSharp.UdonSyncedAttribute, UdonSharp.Runtime
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncer.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncer.cs
@@ -38,19 +38,21 @@ namespace CenturionCC.System.Player
             _localWeaponType = other._localWeaponType;
             _localState = other._localState;
             _localType = other._localType;
+            _localResultContext = other._localResultContext;
 
             ResendCount = ++other.ResendCount;
 
             RequestSync();
         }
 
-        public void UpdateResult(SyncResult result)
+        public void UpdateResult(SyncResult result, byte resultContext)
         {
             _hasProcessed = false;
 
             LastUsedTime = Time.realtimeSinceStartup;
 
             _localResult = result;
+            _localResultContext = resultContext;
             _localState = SyncState.Received;
 
             RequestSync();
@@ -68,7 +70,8 @@ namespace CenturionCC.System.Player
             SyncState state,
             SyncResult result,
             KillType type,
-            BodyParts parts
+            BodyParts parts,
+            byte resultContext
         )
         {
             _hasProcessed = false;
@@ -89,6 +92,7 @@ namespace CenturionCC.System.Player
             _localResult = result;
             _localType = type;
             _localParts = parts;
+            _localResultContext = resultContext;
 
             ResendCount = 0;
 
@@ -116,6 +120,7 @@ namespace CenturionCC.System.Player
             Result = _localResult;
             Type = _localType;
             Parts = _localParts;
+            ResultContext = _localResultContext;
         }
 
         public void ApplyGlobal()
@@ -148,6 +153,7 @@ namespace CenturionCC.System.Player
             _localResult = Result;
             _localType = Type;
             _localParts = Parts;
+            _localResultContext = ResultContext;
         }
 
         public void MakeAvailable()
@@ -177,7 +183,7 @@ namespace CenturionCC.System.Player
                    $"{ActivatedTime:s}/" +
                    $"{HitTime:s}:" +
                    $"{GetStateName(State)}:" +
-                   $"{GetResultName(Result)}:" +
+                   $"{GetResultName(Result)}({ResultContext}):" +
                    $"{GetKillTypeName(Type)}:" +
                    $"{GetBodyPartsName(Parts)}|" +
                    $"{ResendCount}";
@@ -193,7 +199,7 @@ namespace CenturionCC.System.Player
                    $"{_localActivatedTime:s}/" +
                    $"{_localHitTime:s}:" +
                    $"{GetStateName(_localState)}:" +
-                   $"{GetResultName(_localResult)}:" +
+                   $"{GetResultName(_localResult)}({_localResultContext}):" +
                    $"{GetKillTypeName(_localType)}:" +
                    $"{GetBodyPartsName(_localParts)}|" +
                    $"{ResendCount}";
@@ -259,6 +265,7 @@ namespace CenturionCC.System.Player
         private BodyParts _localParts;
         private int _localVictimId;
         private string _localWeaponType;
+        private byte _localResultContext;
 
         #endregion
 
@@ -291,6 +298,8 @@ namespace CenturionCC.System.Player
         public SyncResult Result { get; private set; } = SyncResult.Unassigned;
         public KillType Type { get; private set; } = KillType.Default;
         public BodyParts Parts { get; private set; } = BodyParts.Body;
+        [field: UdonSynced]
+        public byte ResultContext { get; private set; }
         [field: UdonSynced]
         public long EncodedData { get; private set; }
 

--- a/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncerManager.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/DamageDataSyncerManager.cs
@@ -192,7 +192,8 @@ namespace CenturionCC.System.Player
                 SyncState.Sending,
                 SyncResult.Unassigned,
                 killType,
-                pCol.parts
+                pCol.parts,
+                0x00
             );
 
             logger.LogVerbose($"{Prefix}Sending request {syncer.GetLocalInfo()}");
@@ -210,7 +211,16 @@ namespace CenturionCC.System.Player
             logger.LogVerbose($"{Prefix}Received {requester.GetGlobalInfo()}");
 
             if (requester.State == SyncState.Sending && requester.VictimId == _local.playerId)
-                requester.UpdateResult(resolver.Resolve(requester));
+            {
+                if (!resolver.Resolve(requester, out var result, out var context))
+                {
+                    Debug.LogError(
+                        $"{Prefix}{requester.GetGlobalInfo()} has requested resolve, but resolver rejected it");
+                    return;
+                }
+
+                requester.UpdateResult(result, context);
+            }
 
             AddResolvedEventId(requester);
             Invoke_OnReceiveCallback(requester);


### PR DESCRIPTION
Adds `byte ResultContext` for hit data struct. This will help identifying why hit cancel has occurred, and can be used to let players know why it has cancelled.