### PR TITLE
Add editor-time error prevention for GunRecoilPatternDataStore

### DIFF
--- a/Packages/org.centurioncc.system/Editor/EditorInspector/Gun/DataStore/GunRecoilPatternDataStoreEditor.cs
+++ b/Packages/org.centurioncc.system/Editor/EditorInspector/Gun/DataStore/GunRecoilPatternDataStoreEditor.cs
@@ -10,16 +10,38 @@ namespace CenturionCC.System.Editor.EditorInspector.Gun.DataStore
     public class GunRecoilPatternDataStoreEditor : UnityEditor.Editor
     {
         private int _maxPatterns;
+        private SerializedProperty _positionOffsetPatternsProperty;
+
+        private SerializedProperty _recoilOffsetPatternsProperty;
+        private bool _showMinArraySizeHelpBox;
+        private SerializedProperty _speedOffsetPatternsProperty;
 
         private void OnEnable()
         {
             _maxPatterns = ((GunRecoilPatternDataStore)target).MaxPatterns;
+
+            _recoilOffsetPatternsProperty = serializedObject.FindProperty("recoilOffsetPatterns");
+            _positionOffsetPatternsProperty = serializedObject.FindProperty("positionOffsetPatterns");
+            _speedOffsetPatternsProperty = serializedObject.FindProperty("speedOffsetPatterns");
+
+            CheckArraysSize();
+        }
+
+        private void OnDisable()
+        {
+            CheckArraysSize();
         }
 
         public override void OnInspectorGUI()
         {
             if (UdonSharpGUI.DrawDefaultUdonSharpBehaviourHeader(target))
                 return;
+
+            if (_showMinArraySizeHelpBox)
+                EditorGUILayout.HelpBox(
+                    "Each patterns require an element for work. At least 1 element will be added automatically.",
+                    MessageType.Warning
+                );
 
             GUILayout.Label("Settings", EditorStyles.boldLabel);
 
@@ -41,6 +63,39 @@ namespace CenturionCC.System.Editor.EditorInspector.Gun.DataStore
             {
                 EditorGUILayout.IntField("Max Patterns", _maxPatterns);
                 EditorGUILayout.HelpBox("Max Patterns does not consider duplicated elements", MessageType.Warning);
+            }
+
+            CheckArraysSize();
+        }
+
+        private void CheckArraysSize()
+        {
+            if (_recoilOffsetPatternsProperty.arraySize <= 0)
+            {
+                _recoilOffsetPatternsProperty.arraySize = 1;
+                ApplyAndUpdate();
+            }
+
+            if (_positionOffsetPatternsProperty.arraySize <= 0)
+            {
+                _positionOffsetPatternsProperty.arraySize = 1;
+                ApplyAndUpdate();
+            }
+
+            if (_speedOffsetPatternsProperty.arraySize <= 0)
+            {
+                _speedOffsetPatternsProperty.arraySize = 1;
+                ApplyAndUpdate();
+            }
+
+            return;
+
+            void ApplyAndUpdate()
+            {
+                serializedObject.ApplyModifiedProperties();
+
+                _showMinArraySizeHelpBox = true;
+                _maxPatterns = ((GunRecoilPatternDataStore)target).MaxPatterns;
             }
         }
     }


### PR DESCRIPTION
Make editor prevent empty arrays. also show helpbox upon prevention.

Closes #187