### PR TITLE
Make use of Mouse Scroll for gun pitch handling

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
+++ b/Packages/org.centurioncc.system/Runtime/Gun/Gun.cs
@@ -1126,27 +1126,10 @@ namespace CenturionCC.System.Gun
                 FireMode = GunUtility.CycleFireMode(FireMode, AvailableFireModes);
             }
 
-            if (Input.GetKeyDown(KeyCode.LeftShift))
+            var scrollDelta = Input.GetAxisRaw("Mouse ScrollWheel") * 80F;
+            if (!Mathf.Approximately(scrollDelta, 0) && !Input.GetKey(KeyCode.LeftShift))
             {
-                CurrentMainHandlePitchOffset = 90;
-                RequestSerialization();
-            }
-
-            if (Input.GetKeyUp(KeyCode.LeftShift))
-            {
-                CurrentMainHandlePitchOffset = 0;
-                RequestSerialization();
-            }
-
-            if (Input.GetKeyDown(KeyCode.PageUp))
-            {
-                CurrentMainHandlePitchOffset -= 5;
-                RequestSerialization();
-            }
-
-            if (Input.GetKeyDown(KeyCode.PageDown))
-            {
-                CurrentMainHandlePitchOffset += 5;
+                CurrentMainHandlePitchOffset += scrollDelta;
                 RequestSerialization();
             }
         }


### PR DESCRIPTION
Desktop users now can change gun's pitch using Mouse Scroll

Originally implemented in #228, Has been adjusted to make handling feel unique
- Removed `LShift` instant gun direction change functionality
- Added `Mouse Scroll` gradual gun direction change functionality
  - `PageUp` `PageDown` keybinding has been removed