### PR TITLE
Fix Player related issues

### DIFF
--- a/Packages/org.centurioncc.system/Runtime/Player/Centurion/CenturionPlayer.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/Centurion/CenturionPlayer.cs
@@ -168,12 +168,17 @@ namespace CenturionCC.System.Player.Centurion
         private void Start()
         {
             LastDamageInfo = DamageInfo.NewEmpty();
-            playerManager.Invoke_OnPlayerAdded(this);
         }
 
         private void OnDestroy()
         {
             playerManager.Invoke_OnPlayerRemoved(this);
+        }
+
+        public override void OnPlayerRestored(VRCPlayerApi player)
+        {
+            if (!player.IsOwner(gameObject)) return;
+            playerManager.Invoke_OnPlayerAdded(this);
         }
 
         public override void SetTeam(int teamId)

--- a/Packages/org.centurioncc.system/Runtime/Player/Centurion/CenturionPlayerManager.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/Centurion/CenturionPlayerManager.cs
@@ -120,30 +120,6 @@ namespace CenturionCC.System.Player.Centurion
             set => cullingDistance = value;
         }
 
-        public override void OnPlayerRestored(VRCPlayerApi player)
-        {
-            var centurionPlayer = (CenturionPlayer)GetPlayer(player);
-            if (!centurionPlayer)
-            {
-                logger.LogError($"{LogPrefix}Could not add restored player: it isn't a CenturionPlayer");
-                return;
-            }
-
-            _cachedCenturionPlayers.Add(centurionPlayer);
-        }
-
-        public override void OnPlayerLeft(VRCPlayerApi player)
-        {
-            var centurionPlayer = (CenturionPlayer)GetPlayer(player);
-            if (!centurionPlayer)
-            {
-                logger.LogError($"{LogPrefix}Could not remove a player: it isn't a CenturionPlayer");
-                return;
-            }
-
-            _cachedCenturionPlayers.Remove(GetPlayer(player));
-        }
-
         public override void PostLateUpdate()
         {
             if (_cachedCenturionPlayers.Count == 0) return;
@@ -151,10 +127,16 @@ namespace CenturionCC.System.Player.Centurion
             _lastUpdatedCenturionPlayerIndex = (_lastUpdatedCenturionPlayerIndex + 1) % _cachedCenturionPlayers.Count;
 
             var centurionPlayer = (CenturionPlayer)_cachedCenturionPlayers[_lastUpdatedCenturionPlayerIndex].Reference;
-            var vrcPlayer = centurionPlayer.VrcPlayer;
-            if (!Utilities.IsValid(vrcPlayer))
+            if (centurionPlayer == null)
             {
-                logger.LogError($"{LogPrefix}Could not update player: vrcPlayer is not valid");
+                logger.LogError($"{LogPrefix}PostLateUpdate: could not update player: destroyed CenturionPlayer is still present in the list at idx of {_lastUpdatedCenturionPlayerIndex}");
+                return;
+            }
+
+            var vrcPlayer = centurionPlayer.VrcPlayer;
+            if (vrcPlayer == null || !Utilities.IsValid(vrcPlayer))
+            {
+                logger.LogError($"{LogPrefix}PostLateUpdate: could not update player: vrcPlayer is not valid");
                 return;
             }
 
@@ -174,28 +156,27 @@ namespace CenturionCC.System.Player.Centurion
 
         public override PlayerBase[] GetPlayers()
         {
-            var players = new VRCPlayerApi[VRCPlayerApi.GetPlayerCount()];
-            var playerBases = new PlayerBase[players.Length];
-            VRCPlayerApi.GetPlayers(players);
-            for (int i = 0; i < players.Length; i++)
+            var players = new PlayerBase[_cachedCenturionPlayers.Count];
+            for (var i = 0; i < players.Length; i++)
             {
-                playerBases[i] = GetPlayer(players[i]);
+                players[i] = (PlayerBase)_cachedCenturionPlayers[i].Reference;
             }
 
-            return playerBases;
+            return players;
         }
 
         public override PlayerBase GetPlayer(VRCPlayerApi vrcPlayer)
         {
             if (!Utilities.IsValid(vrcPlayer)) return null;
 
-            var objects = Networking.GetPlayerObjects(vrcPlayer);
-            foreach (var obj in objects)
+            // you just can't. DataList doesn't support that.
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < _cachedCenturionPlayers.Count; i++)
             {
-                if (!Utilities.IsValid(obj)) continue;
-                var player = obj.GetComponentInChildren<CenturionPlayer>();
-                if (!Utilities.IsValid(player)) continue;
-                return player;
+                var centurionPlayer = (CenturionPlayer)_cachedCenturionPlayers[i].Reference;
+                if (!centurionPlayer || centurionPlayer.VrcPlayer != vrcPlayer) continue;
+
+                return centurionPlayer;
             }
 
             return null;
@@ -238,6 +219,24 @@ namespace CenturionCC.System.Player.Centurion
             return teamColors[teamId];
         }
 
+        public override void Invoke_OnPlayerAdded(PlayerBase player)
+        {
+            if (_cachedCenturionPlayers.Contains(player))
+            {
+                logger.LogWarn($"{LogPrefix}Invoke_OnPlayerAdded: player {player.PlayerId} has already been added");
+                return;
+            }
+
+            _cachedCenturionPlayers.Add(player);
+            base.Invoke_OnPlayerAdded(player);
+        }
+
+        public override void Invoke_OnPlayerRemoved(PlayerBase player)
+        {
+            _cachedCenturionPlayers.Remove(player);
+            base.Invoke_OnPlayerRemoved(player);
+        }
+
         public bool CanDamageFriendly()
         {
             switch (friendlyFireMode)
@@ -270,7 +269,6 @@ namespace CenturionCC.System.Player.Centurion
         }
 
         #region BroadcastRequests
-
         public bool RequestDamageBroadcast(DamageInfo info)
         {
             var localVrcPlayer = Networking.LocalPlayer;
@@ -425,11 +423,9 @@ namespace CenturionCC.System.Player.Centurion
             SendCustomNetworkEvent(NetworkEventTarget.All, nameof(Internal_ApplySimpleCalls),
                 playerId, PlayerBaseSimpleCalls.Revive);
         }
-
         #endregion
 
         #region Internals
-
         public void Internal_ProcessDamageInfo(DamageInfo info)
         {
             var victimPlayer = GetPlayerById(info.VictimId());
@@ -553,7 +549,6 @@ namespace CenturionCC.System.Player.Centurion
                     return;
             }
         }
-
         #endregion
     }
 }

--- a/Packages/org.centurioncc.system/Runtime/Player/PlayerManagerBase.cs
+++ b/Packages/org.centurioncc.system/Runtime/Player/PlayerManagerBase.cs
@@ -71,7 +71,6 @@ namespace CenturionCC.System.Player
         public abstract Color GetTeamColor(int teamId);
 
         #region InternalUtilities
-
         protected void UpdateAllPlayerView()
         {
             var players = GetPlayers();
@@ -80,11 +79,9 @@ namespace CenturionCC.System.Player
                 player.UpdateView();
             }
         }
-
         #endregion
 
         #region GetUtilities
-
         /// <summary>
         /// Retrieves a player instance by their VRC player ID.
         /// </summary>
@@ -267,11 +264,9 @@ namespace CenturionCC.System.Player
         {
             return GetDisplayName(player, unknownName, false);
         }
-
         #endregion
 
         #region CheckUtilities
-
         [PublicAPI]
         public virtual bool IsStaffTeamId(int teamId)
         {
@@ -293,6 +288,8 @@ namespace CenturionCC.System.Player
         [PublicAPI]
         public virtual bool IsFriendly(PlayerBase lhs, PlayerBase rhs)
         {
+            if (!lhs || !rhs) return false;
+
             return (lhs.TeamId == rhs.TeamId && !IsInFreeForAllTeam(lhs)) ||
                    (IsInStaffTeam(lhs) || IsInStaffTeam(rhs));
         }
@@ -314,11 +311,9 @@ namespace CenturionCC.System.Player
         {
             return IsSpecialTeamId(player.TeamId);
         }
-
         #endregion
 
         #region PlayerManagerEvents
-
         protected int CallbackCount;
         protected UdonSharpBehaviour[] EventCallbacks = new UdonSharpBehaviour[5];
 
@@ -529,7 +524,6 @@ namespace CenturionCC.System.Player
                 if (pmCallback) pmCallback.OnPlayerExitedArea(player, area);
             }
         }
-
         #endregion
     }
 }

--- a/Packages/org.centurioncc.system/Samples/Scenes/CenturionSystemSampleScene.unity
+++ b/Packages/org.centurioncc.system/Samples/Scenes/CenturionSystemSampleScene.unity
@@ -61123,7 +61123,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6643646347058339, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a, type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 46449149895424492, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61161,7 +61161,7 @@ PrefabInstance:
     - target: {fileID: 147782357193615307, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 154319959385906916, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61502,7 +61502,7 @@ PrefabInstance:
     - target: {fileID: 838060494055796196, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 847833497271620523, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61607,7 +61607,7 @@ PrefabInstance:
     - target: {fileID: 1049469647299476369, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1090776593422679274, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61639,7 +61639,7 @@ PrefabInstance:
     - target: {fileID: 1121516052970701616, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1142130603570824938, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61668,7 +61668,7 @@ PrefabInstance:
     - target: {fileID: 1244779104957254775, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1264495044117223391, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61723,7 +61723,7 @@ PrefabInstance:
     - target: {fileID: 1322090074894635607, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1328640510444792696, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61820,7 +61820,7 @@ PrefabInstance:
     - target: {fileID: 1462033422124084141, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1481819827771157347, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61835,7 +61835,7 @@ PrefabInstance:
     - target: {fileID: 1524160577511081380, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1568391885216636281, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61889,7 +61889,7 @@ PrefabInstance:
     - target: {fileID: 1736397395670944499, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1764566551980370077, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -61993,12 +61993,12 @@ PrefabInstance:
     - target: {fileID: 2081913964354571335, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2086243049774728848, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2141418575776602350, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62295,7 +62295,7 @@ PrefabInstance:
     - target: {fileID: 2451096867314754993, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2455415403697129033, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62382,7 +62382,7 @@ PrefabInstance:
     - target: {fileID: 2534501537387417370, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2553932742056941062, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62399,7 +62399,7 @@ PrefabInstance:
     - target: {fileID: 2564149416823378397, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2574240599626512730, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62421,7 +62421,7 @@ PrefabInstance:
     - target: {fileID: 2685156290764147928, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2697701939917038927, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62432,12 +62432,12 @@ PrefabInstance:
     - target: {fileID: 2712970341016423353, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2715048360656276513, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2779384116670487276, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62472,7 +62472,7 @@ PrefabInstance:
     - target: {fileID: 2896835244982145863, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2908853406568740937, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62533,7 +62533,7 @@ PrefabInstance:
     - target: {fileID: 3018488653514597538, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3072558262743387781, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62877,7 +62877,7 @@ PrefabInstance:
     - target: {fileID: 3788500209719300308, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3792253168990812483, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -62948,7 +62948,7 @@ PrefabInstance:
     - target: {fileID: 3985810263090723142, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3999095995693041638, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63036,7 +63036,7 @@ PrefabInstance:
     - target: {fileID: 4112177266982091285, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4135176383878487769, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63101,7 +63101,7 @@ PrefabInstance:
     - target: {fileID: 4328164940057598076, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4345905426488379165, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63224,7 +63224,7 @@ PrefabInstance:
     - target: {fileID: 4600808699333064021, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4617417857308790849, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63315,7 +63315,7 @@ PrefabInstance:
     - target: {fileID: 4799381550050041952, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4833368083159419124, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63326,7 +63326,7 @@ PrefabInstance:
     - target: {fileID: 4853288280682859822, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4860934539225297806, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63353,7 +63353,7 @@ PrefabInstance:
     - target: {fileID: 5218038717588688341, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5242345309927079320, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -63488,12 +63488,12 @@ PrefabInstance:
     - target: {fileID: 5468756635034104490, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5471219225434959735, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5472865302271824210, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64226,7 +64226,7 @@ PrefabInstance:
     - target: {fileID: 6968625724345131435, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6977507197774777802, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64253,7 +64253,7 @@ PrefabInstance:
     - target: {fileID: 7076160454945023816, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7086112712909691143, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64417,7 +64417,7 @@ PrefabInstance:
     - target: {fileID: 7477496854063053738, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7520862557716454378, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64512,7 +64512,7 @@ PrefabInstance:
     - target: {fileID: 7643071880581861672, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7678341888183057527, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64660,7 +64660,7 @@ PrefabInstance:
     - target: {fileID: 7913341966956179623, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7930937791938591791, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64671,12 +64671,12 @@ PrefabInstance:
     - target: {fileID: 7942152247835835466, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7949953586196687218, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7951206933109690683, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64906,7 +64906,7 @@ PrefabInstance:
     - target: {fileID: 8494043171078231325, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8513556485054893617, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -64939,7 +64939,7 @@ PrefabInstance:
     - target: {fileID: 8656751487501480044, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8663808906284094282, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -65039,7 +65039,7 @@ PrefabInstance:
     - target: {fileID: 8893956176770484716, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8901166241071286992, guid: 7c8c98bf08e10b446b79a8a5bc7aaa8a,
         type: 3}
@@ -78287,7 +78287,7 @@ PrefabInstance:
     - target: {fileID: 7934202699104147502, guid: 8cfc44ae7f54d4b449f2ecfefe8afc60,
         type: 3}
       propertyPath: _syncMethod
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8977271020178571112, guid: 8cfc44ae7f54d4b449f2ecfefe8afc60,
         type: 3}

--- a/Packages/org.centurioncc.system/Samples/Scenes/CenturionSystemSampleSceneMinified.unity
+++ b/Packages/org.centurioncc.system/Samples/Scenes/CenturionSystemSampleSceneMinified.unity
@@ -47660,8 +47660,8 @@ MonoBehaviour:
   notification: {fileID: 1938280938378434858}
   moderatorTool: {fileID: 0}
   movement: {fileID: 0}
-  version: 1.0.0-alpha.0
-  commitHash: a3a094b452503bbba18817d4664fb473332cc85e
+  version: 1.0.0-alpha.1
+  commitHash: 13254771d2ab58856f6ca8273b54a1b47f44282d
   branch: master
   license: "[Centurion System](https://github.com/Centurion-Creative-Connect/System)
     \xA9 2022 by [Centurion Creative Connect](https://github.com/Centurion-Creative-Connect)
@@ -61297,7 +61297,7 @@ PrefabInstance:
     - target: {fileID: 8178295948521071903, guid: 4b4784d55aef87e40b8689ff2a197128,
         type: 3}
       propertyPath: behaviours.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8178295948521071903, guid: 4b4784d55aef87e40b8689ff2a197128,
         type: 3}
@@ -61313,7 +61313,7 @@ PrefabInstance:
         type: 3}
       propertyPath: behaviours.Array.data[2]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 955216031}
     - target: {fileID: 8178295948521071903, guid: 4b4784d55aef87e40b8689ff2a197128,
         type: 3}
       propertyPath: behaviours.Array.data[3]


### PR DESCRIPTION
- Fixed issue where CenturionPlayer was not ready when it was invoking `PlayerManagerCallbackBase.OnPlayerAdded(PlayerBase)` event
- Fixed CenturionPlayerManager not discarding destroyed CenturionPlayer instances from cached list
- Fixed `PlayerManagerBase.IsFriendly(PlayerBase, PlayerBase)` possibly causing NRE
- Fixed GetPlayers or GetPlayer might return non-ready instances